### PR TITLE
Split honor between group members

### DIFF
--- a/conf/GainHonorGuard.conf.dist
+++ b/conf/GainHonorGuard.conf.dist
@@ -74,4 +74,13 @@ GainHonorGuard.GainHonorRateEnable = 0
 
 GainHonorGuard.GainHonorRate = 1.0
 
+
+#
+#   SplitInGroup
+#   Splits honor between all currently online group members.
+#       Default : 0 (Disabled)
+#
+
+GainHonorGuard.SplitInGroup = 0
+
 ###################################################################################################

--- a/src/GainHonorGuard.cpp
+++ b/src/GainHonorGuard.cpp
@@ -13,14 +13,15 @@
 #include "World.h"
 #include "WorldPacket.h"
 
-bool GainHonorGuardEnable = 1;
-bool GainHonorGuardAnnounceModule = 1;
-bool GainHonorGuardOnGuardKill = 1;
-bool GainHonorGuardOnEliteKill = 1;
-bool GainHonorGuardOnGuardKillAnnounce = 1;
-bool GainHonorGuardOnEliteKillAnnounce = 1;
-bool GainHonorRateEnable = 1;
+bool GainHonorGuardEnable = true;
+bool GainHonorGuardAnnounceModule = true;
+bool GainHonorGuardOnGuardKill = true;
+bool GainHonorGuardOnEliteKill = true;
+bool GainHonorGuardOnGuardKillAnnounce = true;
+bool GainHonorGuardOnEliteKillAnnounce = true;
+bool GainHonorRateEnable = true;
 float GainHonorRate = 1.0;
+bool SplitInGroup = false;
 
 class GainHonorGuardConfig : public WorldScript
 {
@@ -39,20 +40,23 @@ public:
     // Load Configuration Settings
     void SetInitialWorldSettings()
     {
-        GainHonorGuardEnable = sConfigMgr->GetOption<bool>("GainHonorGuard.Enable", 1);
-        GainHonorGuardAnnounceModule = sConfigMgr->GetOption<bool>("GainHonorGuard.Announce", 1);
+        GainHonorGuardEnable = sConfigMgr->GetOption<bool>("GainHonorGuard.Enable", true);
+        GainHonorGuardAnnounceModule = sConfigMgr->GetOption<bool>("GainHonorGuard.Announce", true);
 
         //Gain Honor Settings
-        GainHonorGuardOnGuardKill = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnGuardKill", 0);
-        GainHonorGuardOnEliteKill = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnEliteKill", 0);
+        GainHonorGuardOnGuardKill = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnGuardKill", false);
+        GainHonorGuardOnEliteKill = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnEliteKill", false);
 
         //Announce honor gained
-        GainHonorGuardOnGuardKillAnnounce = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnGuardKillAnnounce", 0);
-        GainHonorGuardOnEliteKillAnnounce = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnEliteKillAnnounce", 0);
+        GainHonorGuardOnGuardKillAnnounce = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnGuardKillAnnounce", false);
+        GainHonorGuardOnEliteKillAnnounce = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorOnEliteKillAnnounce", false);
 
         //Honor Rate
-        GainHonorRateEnable = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorRateEnable", 0);
+        GainHonorRateEnable = sConfigMgr->GetOption<bool>("GainHonorGuard.GainHonorRateEnable", false);
         GainHonorRate = abs(sConfigMgr->GetOption<float>("GainHonorGuard.GainHonorRate", 1.0));
+
+        //Group Split
+        SplitInGroup = sConfigMgr->GetOption<bool>("GainHonorGuard.SplitInGroup", false);
     }
 };
 
@@ -94,98 +98,105 @@ public:
         RewardHonor(player, killed);
     }
 
+    void AddHonorToPlayer(Player* player, Creature* killed, const int groupsize, const uint8 v_level)
+    {
+        player->UpdateHonorFields();
+
+        //Determine level that is gray
+        const uint8 k_level = player->getLevel();
+        const uint8 k_grey = Acore::XP::GetGrayLevel(k_level);
+
+        // If guard or elite is grey to the player then no honor rewarded
+        if (v_level <= k_grey)
+            return;
+
+        float honor_f = ceil(Acore::Honor::hk_honor_at_level_f(k_level) * (v_level - k_grey) / (k_level - k_grey));
+
+        // count the number of playerkills in one day
+        player->ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
+        // and those in a lifetime
+        player->ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
+        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL);
+        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS, killed->getClass());
+        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, killed->getRace());
+        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA, player->GetAreaId());
+        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL, 1, 0, killed);
+
+        //A Gang beatdown of an enemy rewards less honor
+        if (groupsize > 1)
+            honor_f /= groupsize;
+
+        // apply honor multiplier from aura (not stacking-get highest)
+        AddPct(honor_f, player->GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN_PCT));
+        
+
+        //Custom Gain Honor Rate
+        if (GainHonorRateEnable)
+        {
+            honor_f *= GainHonorRate;
+        }
+        else
+        {
+            honor_f *= sWorld->getRate(RATE_HONOR);
+        }
+
+        //sLog->outError("%u: gained honor with a rate: %0.2f", player->GetGUID(), sWorld->getRate(RATE_HONOR));
+
+        // Convert Honor Back to an int to add to player
+        int32 honor = int32(honor_f);
+
+        //Not sure if this works.
+        WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
+        data << honor;
+
+        // add honor points to player
+        player->ModifyHonorPoints(honor);
+
+        player->ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, honor, true);
+
+        //announce to player if honor was gained
+        if (GainHonorGuardOnGuardKill && killed->ToCreature()->IsGuard() && GainHonorGuardOnGuardKillAnnounce)
+        {
+            std::ostringstream ss;
+            ss << "You have been awarded |cff4CFF00%i |rHonor.";
+            ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);
+        }
+        else if (GainHonorGuardOnEliteKill && killed->ToCreature()->isElite() && GainHonorGuardOnEliteKillAnnounce)
+        {
+            std::ostringstream ss;
+            ss << "You have been awarded |cffFF8000%i |rHonor.";
+            ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);
+        }
+    }
+
     //Reward Honor from either a Guard (creature 32768 flag) or Elite kill.
     void RewardHonor(Player* player, Creature* killed)
     {
-        if (GainHonorGuardEnable && player->IsAlive() && !player->InArena() && !player->HasAura(SPELL_AURA_PLAYER_INACTIVE))
-        {
-            if (killed || !killed->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
-            {
-                if ((GainHonorGuardOnGuardKill && killed->ToCreature()->IsGuard()) || (GainHonorGuardOnEliteKill && killed->ToCreature()->isElite()))
+        if (!GainHonorGuardEnable || !player->IsAlive() || player->InArena() || player->HasAura(SPELL_AURA_PLAYER_INACTIVE))
+            return;
+        if (!killed && killed->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
+            return;
+        if ((!GainHonorGuardOnGuardKill || !killed->ToCreature()->IsGuard()) && (!GainHonorGuardOnEliteKill || !killed->ToCreature()->isElite()))
+            return;
+
+        const int groupsize = GetNumInGroup(player); //Determine if it was a gang beatdown
+        const uint8 v_level = killed->getLevel();
+
+
+        if (SplitInGroup && player->GetGroup())
+            player->GetGroup()->DoForAllMembers([&](Player* groupMember)
                 {
-                    std::ostringstream ss;
-                    int honor = -1; //Honor is added as an int
-                    float honor_f = (float)honor; //Convert honor to float for calculations
-                    player->UpdateHonorFields();
-
-                    int groupsize = GetNumInGroup(player); //Determine if it was a gang beatdown
-
-                    //Determine level that is gray
-                    uint8 k_level = player->getLevel();
-                    uint8 k_grey = Acore::XP::GetGrayLevel(k_level);
-                    uint8 v_level = killed->getLevel();
-
-                    // If guard or elite is grey to the player then no honor rewarded
-                    if (v_level > k_grey)
-                    {
-                        honor_f = ceil(Acore::Honor::hk_honor_at_level_f(k_level) * (v_level - k_grey) / (k_level - k_grey));
-
-                        // count the number of playerkills in one day
-                        player->ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
-                        // and those in a lifetime
-                        player->ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
-                        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL);
-                        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS, killed->getClass());
-                        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, killed->getRace());
-                        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL_AT_AREA, player->GetAreaId());
-                        player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HONORABLE_KILL, 1, 0, killed);
-
-                        if (killed != nullptr)
-                        {
-                            //A Gang beatdown of an enemy rewards less honor
-                            if (groupsize > 1)
-                                honor_f /= groupsize;
-
-                            // apply honor multiplier from aura (not stacking-get highest)
-                            AddPct(honor_f, player->GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN_PCT));
-                        }
-
-                        //Custom Gain Honor Rate
-                        if (GainHonorRateEnable)
-                        {
-                            honor_f *= GainHonorRate;
-                        }
-                        else
-                        {
-                            honor_f *= sWorld->getRate(RATE_HONOR);
-                        }
-
-                        //sLog->outError("%u: gained honor with a rate: %0.2f", player->GetGUID(), sWorld->getRate(RATE_HONOR));
-
-                        // Convert Honor Back to an int to add to player
-                        honor = int32(honor_f);
-
-                        //Not sure if this works.
-                        WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
-                        data << honor;
-
-                        // add honor points to player
-                        player->ModifyHonorPoints(honor);
-
-                        player->ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, honor, true);
-
-                        //announce to player if honor was gained
-                        if (GainHonorGuardOnGuardKill && killed->ToCreature()->IsGuard() && GainHonorGuardOnGuardKillAnnounce)
-                        {
-                            ss << "You have been awarded |cff4CFF00%i |rHonor.";
-                            ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);
-                        }
-                        else if (GainHonorGuardOnEliteKill && killed->ToCreature()->isElite() && GainHonorGuardOnEliteKillAnnounce)
-                        {
-                            ss << "You have been awarded |cffFF8000%i |rHonor.";
-                            ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), honor);
-                        }
-                    }
-                }
-            }
-        }
+                    AddHonorToPlayer(player, killed, groupsize, v_level);
+                });
+        else
+            AddHonorToPlayer(player, killed, groupsize, v_level);
     }
 
     // Get the player's group size
     int GetNumInGroup(Player* player)
     {
         int numInGroup = 1;
-        Group *group = player->GetGroup();
+        const Group *group = player->GetGroup();
         if (group)
         {
             Group::MemberSlotList const& groupMembers = group->GetMemberSlots();

--- a/src/GainHonorGuard.cpp
+++ b/src/GainHonorGuard.cpp
@@ -186,7 +186,7 @@ public:
         if (SplitInGroup && player->GetGroup())
             player->GetGroup()->DoForAllMembers([&](Player* groupMember)
                 {
-                    AddHonorToPlayer(player, killed, groupsize, v_level);
+                    AddHonorToPlayer(groupMember, killed, groupsize, v_level);
                 });
         else
             AddHonorToPlayer(player, killed, groupsize, v_level);


### PR DESCRIPTION
Some code cleanup (no behavior changes, just inverted some if conditions to reduce the indentation and make it easier tor ead.

Instead of only awarding Honor to the person that dealt the killing blow, award it to all group members.

We already reduce the honor gained by number of group members, but then we only give it to one player, instead of all the players that had part in the kill.

This is not fully correct, as it awards to all group members, not only to group members involved in the kill. I don't know how to check who was involved in killing yet.